### PR TITLE
Changed the color of the placeholder

### DIFF
--- a/src/components/authentication/css/Profile.module.css
+++ b/src/components/authentication/css/Profile.module.css
@@ -19,6 +19,10 @@
     border: 0;
     font-size: 25px;
 }
+.nameInput::placeholder {
+  color: #4055a8; 
+}
+
 .icons{
     gap:25px;
 }


### PR DESCRIPTION
Changed the color of the placeholder. fixes #133 

Before it looked like this :
<img width="306" alt="2023-06-11 22_45_48-ExtraSpace - Brave" src="https://github.com/srivastavaritik/Extraspace-Cloud/assets/76463001/7314536f-efd1-4435-8efd-84f680e16793">

After the change it looks something like this:
<img width="318" alt="2023-06-11 22_48_42-ExtraSpace - Brave" src="https://github.com/srivastavaritik/Extraspace-Cloud/assets/76463001/197ff32e-d417-467d-a82c-8e9561ba07c4">
